### PR TITLE
disable screenshots on testing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
     DIST_IMAGE = 'ubuntu'
     MULTIARCH='true'
     CI='true'
-    CI_WEB='true'
+    CI_WEB='false'
     CI_PORT='8096'
     CI_SSL='false'
     CI_DELAY='120'

--- a/jenkins-vars.yml
+++ b/jenkins-vars.yml
@@ -20,7 +20,7 @@ repo_vars:
   - DIST_IMAGE = 'ubuntu'
   - MULTIARCH='true'
   - CI='true'
-  - CI_WEB='true'
+  - CI_WEB='false'
   - CI_PORT='8096'
   - CI_SSL='false'
   - CI_DELAY='120'


### PR DESCRIPTION
Something about grabbing a screenshot locks up testing. Disable to prevent this. 