### PR TITLE
add umask variable to allow metadata perms to be to user preference

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ docker create \
   -e PUID=1000 \
   -e PGID=1000 \
   -e TZ=Europe/London \
+  -e UMASK_SET=<022> `#optional` \
   -p 8096:8096 \
   -p 8920:8920 `#optional` \
   -v /path/to/library:/config \
@@ -88,6 +89,7 @@ services:
       - PUID=1000
       - PGID=1000
       - TZ=Europe/London
+      - UMASK_SET=<022> #optional
     volumes:
       - /path/to/library:/config
       - /path/to/tvshows:/data/tvshows
@@ -112,6 +114,7 @@ Container images are configured using parameters passed at runtime (such as thos
 | `-e PUID=1000` | for UserID - see below for explanation |
 | `-e PGID=1000` | for GroupID - see below for explanation |
 | `-e TZ=Europe/London` | Specify a timezone to use EG Europe/London |
+| `-e UMASK_SET=<022>` | for umask setting of Emby, default if left unset is 022. |
 | `-v /config` | Emby data storage location. *This can grow very large, 50gb+ is likely for a large collection.* |
 | `-v /data/tvshows` | Media goes here. Add as many as needed e.g. `/data/movies`, `/data/tv`, etc. |
 | `-v /data/movies` | Media goes here. Add as many as needed e.g. `/data/movies`, `/data/tv`, etc. |
@@ -217,5 +220,6 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **13.08.19:** - Add umask environment variable.
 * **24.06.19:** - Fix typos in readme.
 * **30.05.19:** - Initial release.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -33,8 +33,10 @@ param_ports:
 param_usage_include_env: true
 param_env_vars:
   - { env_var: "TZ", env_value: "Europe/London", desc: "Specify a timezone to use EG Europe/London"}
-  - { env_var: "UMASK_SET", env_value: "<022>", desc: "for umask setting of emby, *optional* , default if left unset is 022."}
 # optional container parameters
+opt_param_usage_include_env: true
+opt_param_env_vars:
+  - { env_var: "UMASK_SET", env_value: "<022>", desc: "for umask setting of Emby, default if left unset is 022."}
 opt_param_usage_include_vols: true
 opt_param_volumes:
   - { vol_path: "/transcode", vol_host_path: "/path/for/transcoding", desc: "Path for transcoding folder, *optional*." }

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -33,6 +33,7 @@ param_ports:
 param_usage_include_env: true
 param_env_vars:
   - { env_var: "TZ", env_value: "Europe/London", desc: "Specify a timezone to use EG Europe/London"}
+  - { env_var: "UMASK_SET", env_value: "<022>", desc: "for umask setting of emby, *optional* , default if left unset is 022."}
 # optional container parameters
 opt_param_usage_include_vols: true
 opt_param_volumes:
@@ -66,5 +67,6 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "13.08.19:", desc: "Add umask environment variable." }
   - { date: "24.06.19:", desc: "Fix typos in readme." }
   - { date: "30.05.19:", desc: "Initial release." }

--- a/root/etc/services.d/emby/run
+++ b/root/etc/services.d/emby/run
@@ -1,5 +1,9 @@
 #!/usr/bin/with-contenv bash
 
+# set umask
+UMASK_SET=${UMASK_SET:-022}
+umask "$UMASK_SET"
+
 # env settings
 APP_DIR="/app/emby"
 export LD_LIBRARY_PATH="${APP_DIR}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

+ Allows the umask for emby server to be set
+ Gives control over permissions for all the metadata it can spit out to media folders if set to save to media folders etc.