### PR TITLE
add vaapi drivers for AMD hardware

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,9 @@ LABEL maintainer="thelamer"
 # add needed nvidia environment variables for https://github.com/NVIDIA/nvidia-docker
 ENV NVIDIA_DRIVER_CAPABILITIES="compute,video,utility"
 
+# VAAPI drivers
+RUN apt-get update && apt-get install -y mesa-va-drivers
+
 # add local files
 COPY --from=buildstage /app/emby /app/emby
 COPY root/ /

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,8 +44,17 @@ LABEL maintainer="thelamer"
 # add needed nvidia environment variables for https://github.com/NVIDIA/nvidia-docker
 ENV NVIDIA_DRIVER_CAPABILITIES="compute,video,utility"
 
-# VAAPI drivers
-RUN apt-get update && apt-get install -y mesa-va-drivers
+# install packages
+RUN \
+ echo "**** install packages ****" && \
+ apt-get update && \
+ apt-get install -y --no-install-recommends \
+	mesa-va-drivers && \
+ echo "**** cleanup ****" && \
+ rm -rf \
+	/tmp/* \
+	/var/lib/apt/lists/* \
+	/var/tmp/*
 
 # add local files
 COPY --from=buildstage /app/emby /app/emby

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Container images are configured using parameters passed at runtime (such as thos
 | `-v /data/movies` | Media goes here. Add as many as needed e.g. `/data/movies`, `/data/tv`, etc. |
 | `-v /transcode` | Path for transcoding folder, *optional*. |
 | `-v /opt/vc/lib` | Path for Raspberry Pi OpenMAX libs *optional*. |
-| `--device /dev/dri` | Only needed if you want to use your Intel GPU for hardware accelerated video encoding (vaapi). |
+| `--device /dev/dri` | Only needed if you want to use your Intel or AMD GPU for hardware accelerated video encoding (vaapi). |
 | `--device /dev/vchiq` | Only needed if you want to use your Raspberry Pi OpenMax video encoding (Bellagio). |
 | `--device /dev/video10` | Only needed if you want to use your Raspberry Pi V4L2 video encoding. |
 | `--device /dev/video11` | Only needed if you want to use your Raspberry Pi V4L2 video encoding. |
@@ -187,7 +187,7 @@ Webui can be found at `http://<your-ip>:8096`
 
 Emby has very complete and verbose documentation located [here](https://github.com/MediaBrowser/Wiki/wiki) .
 
-Hardware acceleration users for Intel Quicksync will need to mount their /dev/dri video device inside of the container by passing the following command when running or creating the container:
+Hardware acceleration users for Intel Quicksync and AMD VAAPI will need to mount their /dev/dri video device inside of the container by passing the following command when running or creating the container:
 
 ```--device=/dev/dri:/dev/dri```
 
@@ -287,6 +287,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **03.07.20:** - Add support for amd vaapi hw transcode.
 * **29.02.20:** - Add v4l2 support on Raspberry Pi.
 * **26.02.20:** - Add openmax support on Raspberry Pi.
 * **15.02.20:** - Allow restarting emby from the gui (also allows for auto restarts after addon updates).

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -43,7 +43,7 @@ opt_param_volumes:
   - { vol_path: "/opt/vc/lib", vol_host_path: "/opt/vc/lib", desc: "Path for Raspberry Pi OpenMAX libs *optional*." }
 opt_param_device_map: true
 opt_param_devices:
-  - { device_path: "/dev/dri", device_host_path: "/dev/dri", desc: "Only needed if you want to use your Intel GPU for hardware accelerated video encoding (vaapi)." }
+  - { device_path: "/dev/dri", device_host_path: "/dev/dri", desc: "Only needed if you want to use your Intel or AMD GPU for hardware accelerated video encoding (vaapi)." }
   - { device_path: "/dev/vchiq", device_host_path: "/dev/vchiq", desc: "Only needed if you want to use your Raspberry Pi OpenMax video encoding (Bellagio)." }
   - { device_path: "/dev/video10", device_host_path: "/dev/video10", desc: "Only needed if you want to use your Raspberry Pi V4L2 video encoding." }
   - { device_path: "/dev/video11", device_host_path: "/dev/video11", desc: "Only needed if you want to use your Raspberry Pi V4L2 video encoding." }
@@ -60,7 +60,7 @@ app_setup_block: |
 
   Emby has very complete and verbose documentation located [here](https://github.com/MediaBrowser/Wiki/wiki) .
 
-  Hardware acceleration users for Intel Quicksync will need to mount their /dev/dri video device inside of the container by passing the following command when running or creating the container:
+  Hardware acceleration users for Intel Quicksync and AMD VAAPI will need to mount their /dev/dri video device inside of the container by passing the following command when running or creating the container:
 
   ```--device=/dev/dri:/dev/dri```
 
@@ -91,6 +91,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "03.07.20:", desc: "Add support for amd vaapi hw transcode." }
   - { date: "29.02.20:", desc: "Add v4l2 support on Raspberry Pi." }
   - { date: "26.02.20:", desc: "Add openmax support on Raspberry Pi." }
   - { date: "15.02.20:", desc: "Allow restarting emby from the gui (also allows for auto restarts after addon updates)." }

--- a/root/etc/services.d/emby/run
+++ b/root/etc/services.d/emby/run
@@ -9,7 +9,7 @@ APP_DIR="/app/emby"
 export LD_LIBRARY_PATH="${APP_DIR}"
 export FONTCONFIG_PATH="${APP_DIR}"/etc/fonts
 if [ -d "/lib/x86_64-linux-gnu" ]; then
-	export LIBVA_DRIVERS_PATH="${APP_DIR}"/dri
+	export LIBVA_DRIVERS_PATH=/usr/lib/x86_64-linux-gnu/dri:"${APP_DIR}"/dri
 fi
 export SSL_CERT_FILE="${APP_DIR}"/etc/ssl/certs/ca-certificates.crt
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo in code or documentation in the README please file an issue and let us sort it out we do not need a PR  --> 
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

We welcome all PR’s though this doesn’t guarantee it will be accepted.

## Description:
<!--- Describe your changes in detail -->
Install the Mesa VAAPI drivers to be able to use the device. Updated the ENV variable so that the ffmpeg, ffdetect binaries shipped with emby can use the drivers.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
Started discussion at https://github.com/linuxserver/docker-baseimage-ubuntu/issues/44 and it was pointed out that it should be fixed in this specific repo instead.
Benefit is that AMD users can use HW accelerated video encoding and decoding out of the box iff they have a Emby Premiere subscription. 

## How Has This Been Tested?
Locally build the docker image and used it as with docker-compose as described in the original Readme

