### PR TITLE
Focal master

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN \
 	/tmp/opt/emby-server/etc
 
 # runtime stage
-FROM ghcr.io/linuxserver/baseimage-ubuntu:bionic
+FROM ghcr.io/linuxserver/baseimage-ubuntu:focal
 
 # set version label
 ARG BUILD_DATE

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -44,10 +44,6 @@ LABEL maintainer="thelamer"
 ENV NVIDIA_DRIVER_CAPABILITIES="compute,video,utility"
 
 RUN \
- echo "**** install packages ****" && \
- apt-get update && \
- apt-get install -y --no-install-recommends \
-	gnupg && \
  echo "**** add emby deps *****" && \
  curl -s https://keyserver.ubuntu.com/pks/lookup?op=get\&search=0x6587ffd6536b8826e88a62547876ae518cbcf2f2 | apt-key add - && \
  echo "deb http://ppa.launchpad.net/ubuntu-raspi2/ppa-nightly/ubuntu bionic main">> /etc/apt/sources.list.d/raspbins.list && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -46,7 +46,7 @@ ENV NVIDIA_DRIVER_CAPABILITIES="compute,video,utility"
 RUN \
  echo "**** add emby deps *****" && \
  curl -s https://keyserver.ubuntu.com/pks/lookup?op=get\&search=0x6587ffd6536b8826e88a62547876ae518cbcf2f2 | apt-key add - && \
- echo "deb http://ppa.launchpad.net/ubuntu-raspi2/ppa-nightly/ubuntu bionic main">> /etc/apt/sources.list.d/raspbins.list && \
+ echo "deb http://ppa.launchpad.net/ubuntu-raspi2/ppa-nightly/ubuntu focal main">> /etc/apt/sources.list.d/raspbins.list && \
  apt-get update && \
  apt-get install -y --no-install-recommends \
 	libomxil-bellagio0 \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -32,7 +32,7 @@ RUN \
 	/tmp/opt/emby-server/etc
 
 # runtime stage
-FROM ghcr.io/linuxserver/baseimage-ubuntu:bionic
+FROM ghcr.io/linuxserver/baseimage-ubuntu:focal
 
 # set version label
 ARG BUILD_DATE
@@ -44,11 +44,18 @@ LABEL maintainer="thelamer"
 ENV NVIDIA_DRIVER_CAPABILITIES="compute,video,utility"
 
 RUN \
- echo "**** add emby deps ****" && \
+ echo "**** install packages ****" && \
+ apt-get update && \
+ apt-get install -y --no-install-recommends \
+	gnupg && \
+ echo "**** add emby deps *****" && \
+ curl -s https://keyserver.ubuntu.com/pks/lookup?op=get\&search=0x6587ffd6536b8826e88a62547876ae518cbcf2f2 | apt-key add - && \
+ echo "deb http://ppa.launchpad.net/ubuntu-raspi2/ppa-nightly/ubuntu bionic main">> /etc/apt/sources.list.d/raspbins.list && \
  apt-get update && \
  apt-get install -y --no-install-recommends \
 	libomxil-bellagio0 \
-	libomxil-bellagio-bin && \
+	libomxil-bellagio-bin \
+	libraspberrypi-bin-nonfree && \
  echo "**** cleanup ****" && \
  rm -rf \
 	/tmp/* \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,4 +1,4 @@
-FROM ghcr.io/linuxserver/baseimage-ubuntu:bionic as buildstage
+FROM ghcr.io/linuxserver/baseimage-ubuntu:arm64v8-bionic as buildstage
 
 # build args
 ARG EMBY_RELEASE
@@ -32,7 +32,7 @@ RUN \
 	/tmp/opt/emby-server/etc
 
 # runtime stage
-FROM ghcr.io/linuxserver/baseimage-ubuntu:focal
+FROM ghcr.io/linuxserver/baseimage-ubuntu:arm64v8-focal
 
 # set version label
 ARG BUILD_DATE
@@ -51,7 +51,7 @@ RUN \
  apt-get install -y --no-install-recommends \
 	libomxil-bellagio0 \
 	libomxil-bellagio-bin \
-	libraspberrypi-bin-nonfree && \
+	libraspberrypi0 && \
  echo "**** cleanup ****" && \
  rm -rf \
 	/tmp/* \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -32,7 +32,7 @@ RUN \
 	/tmp/opt/emby-server/etc
 
 # runtime stage
-FROM ghcr.io/linuxserver/baseimage-ubuntu:arm32v7-bionic
+FROM ghcr.io/linuxserver/baseimage-ubuntu:arm32v7-focal
 
 # set version label
 ARG BUILD_DATE
@@ -44,18 +44,14 @@ LABEL maintainer="thelamer"
 ENV NVIDIA_DRIVER_CAPABILITIES="compute,video,utility"
 
 RUN \
- echo "**** install packages ****" && \
- apt-get update && \
- apt-get install -y --no-install-recommends \
-	gnupg && \
  echo "**** add emby deps *****" && \
  curl -s https://keyserver.ubuntu.com/pks/lookup?op=get\&search=0x6587ffd6536b8826e88a62547876ae518cbcf2f2 | apt-key add - && \
- echo "deb http://ppa.launchpad.net/ubuntu-raspi2/ppa/ubuntu bionic main">> /etc/apt/sources.list.d/raspbins.list && \
+ echo "deb http://ppa.launchpad.net/ubuntu-raspi2/ppa-nightly/ubuntu focal main">> /etc/apt/sources.list.d/raspbins.list && \
  apt-get update && \
  apt-get install -y --no-install-recommends \
 	libomxil-bellagio0 \
 	libomxil-bellagio-bin \
-	libraspberrypi0 && \
+	libraspberrypi-bin-nonfree && \
  echo "**** cleanup ****" && \
  rm -rf \
 	/tmp/* \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -51,7 +51,7 @@ RUN \
  apt-get install -y --no-install-recommends \
 	libomxil-bellagio0 \
 	libomxil-bellagio-bin \
-	libraspberrypi-bin-nonfree && \
+	libraspberrypi0 && \
  echo "**** cleanup ****" && \
  rm -rf \
 	/tmp/* \

--- a/README.md
+++ b/README.md
@@ -291,6 +291,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **21.12.20:** - Rebase to Focal, see [here](https://docs.linuxserver.io/faq#my-host-is-incompatible-with-images-based-on-ubuntu-focal) for troubleshooting armhf.
 * **03.11.20:** - Fix issue with missing samba folder.
 * **13.11.20:** - Fix issue with samba and ffmpeg.
 * **03.07.20:** - Add support for amd vaapi hw transcode.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -91,6 +91,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "21.12.20:", desc: "Rebase to Focal, see [here](https://docs.linuxserver.io/faq#my-host-is-incompatible-with-images-based-on-ubuntu-focal) for troubleshooting armhf." }
   - { date: "03.11.20:", desc: "Fix issue with missing samba folder." }
   - { date: "13.11.20:", desc: "Fix issue with samba and ffmpeg." }
   - { date: "03.07.20:", desc: "Add support for amd vaapi hw transcode." }


### PR DESCRIPTION
This rebases to focal and adds Pi libs to the aarch64 image which was actually broken all this time. 
I am not really sure of the implications with this one, we actually pull in from their RPM specifically because it bundles everything it needs for the core program, but rebasing to focal might break some debian and Bionic users expecting hardware support potentially, all we add sys level on the x86 variant is mesa. 