### PR TITLE
Don't chown /data (user's media)

### DIFF
--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -10,7 +10,3 @@ chown abc:abc \
 	/config \
 	/data \
 	/transcode
-if [ -n "$(ls -A /data 2>/dev/null)" ]; then
-chown abc:abc \
-	/data/*
-fi

--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -8,5 +8,4 @@ mkdir -p \
 # permissions (non-recursive) on config root and folders
 chown abc:abc \
 	/config \
-	/data \
 	/transcode


### PR DESCRIPTION
The container init scripts currently chown both /config (reasonable) and /data - the latter seems very unreasonable. The jellyfin container also did this; following the discussion in https://github.com/linuxserver/docker-jellyfin/issues/62 this has been changed. The plex container to my knowledge has never done this.

For consistency and sanity we should change it here too.(fixes #51)