### PR TITLE
Add support for MediaInfo plugin on amd64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,14 @@ RUN \
   apt-get install -y \
     cpio \
     jq \
-    rpm2cpio && \
+    rpm2cpio \
+    unzip && \  
+  echo "**** install roku bif tool ****" && \
+  curl -o \
+    /tmp/biftool_linux.zip -L \
+    "https://github.com/rokudev/samples/raw/master/utilities/bif%20tool/biftool_linux.zip" && \
+  cd /tmp && \
+  unzip biftool_linux.zip -d /app/biftool_linux && \
   echo "**** install emby ****" && \
   mkdir -p \
     /app/emby && \
@@ -51,7 +58,9 @@ RUN \
   echo "**** install packages ****" && \
   apt-get update && \
   apt-get install -y --no-install-recommends \
+    mediainfo \
     mesa-va-drivers \
+    mkvtoolnix \
     netcat && \
   echo "**** cleanup ****" && \
   rm -rf \
@@ -61,6 +70,7 @@ RUN \
 
 # add local files
 COPY --from=buildstage /app/emby /app/emby
+COPY --from=buildstage /app/biftool_linux /usr/bin
 COPY root/ /
 
 # ports and volumes

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -90,6 +90,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "11.12.22:", desc: "Add support for MediaInfo Plugin on amd64"}
   - { date: "26.09.22:", desc: "Update chown behavior." }
   - { date: "18.09.22:", desc: "Migrate to s6v3, rebase to Ubuntu Jammy." }
   - { date: "19.05.21:", desc: "Structural changes upstream." }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [X ] I have read the [contributing](https://github.com/linuxserver/docker-emby/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
Added MediaInfo, MKVToolNix and the BIF file creation tool to the amd64 dockerfile.

## Benefits of this PR and context:
Allows a user with Emby on amd64 to utilize the MediaInfo plugin.  The plugin's current solution requires the user to install MediaInfo, MKVToolNix and the BIF tool on the base operating system and then call them from the Emby container-{https://github.com/Cheesegeezer/MediaInfoWiki/wiki/Various-OS-Installation-Help#5-docker}.  The new dockerfile includes these applications within the docker container and enables full functionality of the MediaInfo plugin.

## How Has This Been Tested?
Built the docker container on and amd64 and tested in on and amd64 platform running Ubuntu 20.04.  Emby was started and the plugin ran.  All media tags were updated.  Emby must have write priviliges to all media files for the plugin to run correctlly.

## Source / References:
None.
