### PR TITLE
use deb, simplify Dockerfiles

### DIFF
--- a/.github/workflows/external_trigger.yml
+++ b/.github/workflows/external_trigger.yml
@@ -72,7 +72,7 @@ jobs:
           else
             echo "**** New version ${EXT_RELEASE} found; old version was ${IMAGE_VERSION}. Checking artifacts. . . ****"
             assets=$(curl -u "${{ secrets.CR_USER }}:${{ secrets.CR_PAT }}" -sX GET "https://api.github.com/repos/MediaBrowser/Emby.Releases/releases/tags/${EXT_RELEASE}" | jq -r '.assets[].browser_download_url')
-            if echo "$assets" | grep -q "aarch64.rpm$" && echo "$assets" | grep -q "armv7hl.rpm$" && echo "$assets" | grep -q "x86_64.rpm$"; then
+            if echo "$assets" | grep -q "arm64.deb$" && echo "$assets" | grep -q "armhf.deb$" && echo "$assets" | grep -q "amd64.deb$"; then
               echo "**** All artifacts seem to be published, triggering build ****"
               response=$(curl -iX POST \
                 https://ci.linuxserver.io/job/Docker-Pipeline-Builders/job/docker-emby/job/master/buildWithParameters?PACKAGE_CHECK=false \

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,8 @@ RUN \
     /tmp/opt/emby-server/extra/lib/* && \
   echo "**** cleanup ****" && \
   rm -rf \
-    /tmp/*
+    /tmp/* && \
+  chmod go+w /tmp
 
 # add local files
 COPY root/ /

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
-
 # syntax=docker/dockerfile:1
 
 FROM ghcr.io/linuxserver/baseimage-ubuntu:jammy

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,43 +1,12 @@
-FROM ghcr.io/linuxserver/baseimage-ubuntu:jammy as buildstage
 
-# build args
-ARG EMBY_RELEASE
-ENV DEBIAN_FRONTEND="noninteractive" 
+# syntax=docker/dockerfile:1
 
-RUN \
-  echo "**** install packages ****" && \
-  apt-get update && \
-  apt-get install -y \
-    cpio \
-    jq \
-    rpm2cpio && \
-  echo "**** install emby ****" && \
-  mkdir -p \
-    /app/emby && \
-  if [ -z ${EMBY_RELEASE+x} ]; then \
-    EMBY_RELEASE=$(curl -s https://api.github.com/repos/MediaBrowser/Emby.Releases/releases/latest \
-    | jq -r '. | .tag_name'); \
-  fi && \
-  curl -o \
-    /tmp/emby.rpm -L \
-    "https://github.com/MediaBrowser/Emby.Releases/releases/download/${EMBY_RELEASE}/emby-server-rpm_${EMBY_RELEASE}_x86_64.rpm" && \
-  cd /tmp && \
-  rpm2cpio emby.rpm \
-    | cpio -i --make-directories && \
-  mv -t \
-    /app/emby/ \
-    /tmp/opt/emby-server/system/* \
-    /tmp/opt/emby-server/lib/* \
-    /tmp/opt/emby-server/bin/ff* \
-    /tmp/opt/emby-server/etc \
-    /tmp/opt/emby-server/extra/lib/*
-
-# runtime stage
 FROM ghcr.io/linuxserver/baseimage-ubuntu:jammy
 
 # set version label
 ARG BUILD_DATE
 ARG VERSION
+ARG EMBY_RELEASE
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL maintainer="thelamer"
 
@@ -48,19 +17,29 @@ ENV NVIDIA_DRIVER_CAPABILITIES="compute,video,utility"
 
 # install packages
 RUN \
-  echo "**** install packages ****" && \
-  apt-get update && \
-  apt-get install -y --no-install-recommends \
-    mesa-va-drivers \
-    netcat && \
+  echo "**** install emby ****" && \
+  mkdir -p \
+    /app/emby && \
+  if [ -z ${EMBY_RELEASE+x} ]; then \
+    EMBY_RELEASE=$(curl -s https://api.github.com/repos/MediaBrowser/Emby.Releases/releases/latest \
+    | jq -r '. | .tag_name'); \
+  fi && \
+  curl -o \
+    /tmp/emby.deb -L \
+    "https://github.com/MediaBrowser/Emby.Releases/releases/download/${EMBY_RELEASE}/emby-server-deb_${EMBY_RELEASE}_amd64.deb" && \
+  dpkg-deb -xv /tmp/emby.deb /tmp/ && \
+  mv -t \
+    /app/emby/ \
+    /tmp/opt/emby-server/system/* \
+    /tmp/opt/emby-server/lib/* \
+    /tmp/opt/emby-server/bin/ff* \
+    /tmp/opt/emby-server/etc \
+    /tmp/opt/emby-server/extra/lib/* && \
   echo "**** cleanup ****" && \
   rm -rf \
-    /tmp/* \
-    /var/lib/apt/lists/* \
-    /var/tmp/*
+    /tmp/*
 
 # add local files
-COPY --from=buildstage /app/emby /app/emby
 COPY root/ /
 
 # ports and volumes

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,6 @@ RUN \
   mkdir -p \
     /app/emby \
     /tmpnetcore && \
-  chmod go+w /tmpnetcore && \
   if [ -z ${EMBY_RELEASE+x} ]; then \
     EMBY_RELEASE=$(curl -s https://api.github.com/repos/MediaBrowser/Emby.Releases/releases/latest \
     | jq -r '. | .tag_name'); \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,9 @@ ENV NVIDIA_DRIVER_CAPABILITIES="compute,video,utility"
 RUN \
   echo "**** install emby ****" && \
   mkdir -p \
-    /app/emby && \
+    /app/emby \
+    /tmpnetcore && \
+  chmod go+w /tmpnetcore && \
   if [ -z ${EMBY_RELEASE+x} ]; then \
     EMBY_RELEASE=$(curl -s https://api.github.com/repos/MediaBrowser/Emby.Releases/releases/latest \
     | jq -r '. | .tag_name'); \
@@ -37,8 +39,7 @@ RUN \
     /tmp/opt/emby-server/extra/lib/* && \
   echo "**** cleanup ****" && \
   rm -rf \
-    /tmp/* && \
-  chmod go+w /tmp
+    /tmp/*
 
 # add local files
 COPY root/ /

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -45,7 +45,8 @@ RUN \
   rm -rf \
     /tmp/* \
     /var/lib/apt/lists/* \
-    /var/tmp/*
+    /var/tmp/* && \
+  chmod go+w /tmp
 
 # add local files
 COPY root/ /

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -16,8 +16,8 @@ ENV NVIDIA_DRIVER_CAPABILITIES="compute,video,utility"
 
 RUN \
   echo "**** add emby deps *****" && \
-  curl -s https://keyserver.ubuntu.com/pks/lookup?op=get\&search=0x6587ffd6536b8826e88a62547876ae518cbcf2f2 | apt-key add - && \
-  echo "deb http://ppa.launchpad.net/ubuntu-raspi2/ppa-nightly/ubuntu focal main">> /etc/apt/sources.list.d/raspbins.list && \
+  curl -s https://keyserver.ubuntu.com/pks/lookup?op=get\&search=0x6587ffd6536b8826e88a62547876ae518cbcf2f2 | gpg --dearmor | tee /usr/share/keyrings/raspbins.gpg >/dev/null && \
+  echo "deb [signed-by=/usr/share/keyrings/raspbins.gpg] http://ppa.launchpad.net/ubuntu-raspi2/ppa-nightly/ubuntu focal main">> /etc/apt/sources.list.d/raspbins.list && \
   apt-get update && \
   apt-get install -y --no-install-recommends \
     libomxil-bellagio0 \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -25,7 +25,9 @@ RUN \
     libraspberrypi0 && \
   echo "**** install emby ****" && \
   mkdir -p \
-    /app/emby && \
+    /app/emby \
+    /tmpnetcore && \
+  chmod go+w /tmpnetcore && \
   if [ -z ${EMBY_RELEASE+x} ]; then \
     EMBY_RELEASE=$(curl -s https://api.github.com/repos/MediaBrowser/Emby.Releases/releases/latest \
     | jq -r '. | .tag_name'); \
@@ -45,8 +47,7 @@ RUN \
   rm -rf \
     /tmp/* \
     /var/lib/apt/lists/* \
-    /var/tmp/* && \
-  chmod go+w /tmp
+    /var/tmp/*
 
 # add local files
 COPY root/ /

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,43 +1,11 @@
-FROM ghcr.io/linuxserver/baseimage-ubuntu:arm64v8-jammy as buildstage
+# syntax=docker/dockerfile:1
 
-# build args
-ARG EMBY_RELEASE
-ENV DEBIAN_FRONTEND="noninteractive" 
-
-RUN \
-  echo "**** install packages ****" && \
-  apt-get update && \
-  apt-get install -y \
-    cpio \
-    jq \
-    rpm2cpio && \
-  echo "**** install emby ****" && \
-  mkdir -p \
-    /app/emby && \
-  if [ -z ${EMBY_RELEASE+x} ]; then \
-    EMBY_RELEASE=$(curl -s https://api.github.com/repos/MediaBrowser/Emby.Releases/releases/latest \
-    | jq -r '. | .tag_name'); \
-  fi && \
-  curl -o \
-    /tmp/emby.rpm -L \
-    "https://github.com/MediaBrowser/Emby.Releases/releases/download/${EMBY_RELEASE}/emby-server-rpm_${EMBY_RELEASE}_aarch64.rpm" && \
-  cd /tmp && \
-  rpm2cpio emby.rpm \
-    | cpio -i --make-directories && \
-  mv -t \
-    /app/emby/ \
-    /tmp/opt/emby-server/system/* \
-    /tmp/opt/emby-server/lib/* \
-    /tmp/opt/emby-server/bin/ff* \
-    /tmp/opt/emby-server/etc \
-    /tmp/opt/emby-server/extra/lib/*
-
-# runtime stage
 FROM ghcr.io/linuxserver/baseimage-ubuntu:arm64v8-jammy
 
 # set version label
 ARG BUILD_DATE
 ARG VERSION
+ARG EMBY_RELEASE
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL maintainer="thelamer"
 
@@ -54,8 +22,25 @@ RUN \
   apt-get install -y --no-install-recommends \
     libomxil-bellagio0 \
     libomxil-bellagio-bin \
-    libraspberrypi0 \
-    netcat && \
+    libraspberrypi0 && \
+  echo "**** install emby ****" && \
+  mkdir -p \
+    /app/emby && \
+  if [ -z ${EMBY_RELEASE+x} ]; then \
+    EMBY_RELEASE=$(curl -s https://api.github.com/repos/MediaBrowser/Emby.Releases/releases/latest \
+    | jq -r '. | .tag_name'); \
+  fi && \
+  curl -o \
+    /tmp/emby.deb -L \
+    "https://github.com/MediaBrowser/Emby.Releases/releases/download/${EMBY_RELEASE}/emby-server-deb_${EMBY_RELEASE}_armh64.deb" && \
+  dpkg-deb -xv /tmp/emby.deb /tmp/ && \
+  mv -t \
+    /app/emby/ \
+    /tmp/opt/emby-server/system/* \
+    /tmp/opt/emby-server/lib/* \
+    /tmp/opt/emby-server/bin/ff* \
+    /tmp/opt/emby-server/etc \
+    /tmp/opt/emby-server/extra/lib/* && \
   echo "**** cleanup ****" && \
   rm -rf \
     /tmp/* \
@@ -63,7 +48,6 @@ RUN \
     /var/tmp/*
 
 # add local files
-COPY --from=buildstage /app/emby /app/emby
 COPY root/ /
 
 # ports and volumes

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -27,7 +27,6 @@ RUN \
   mkdir -p \
     /app/emby \
     /tmpnetcore && \
-  chmod go+w /tmpnetcore && \
   if [ -z ${EMBY_RELEASE+x} ]; then \
     EMBY_RELEASE=$(curl -s https://api.github.com/repos/MediaBrowser/Emby.Releases/releases/latest \
     | jq -r '. | .tag_name'); \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -32,7 +32,7 @@ RUN \
   fi && \
   curl -o \
     /tmp/emby.deb -L \
-    "https://github.com/MediaBrowser/Emby.Releases/releases/download/${EMBY_RELEASE}/emby-server-deb_${EMBY_RELEASE}_armh64.deb" && \
+    "https://github.com/MediaBrowser/Emby.Releases/releases/download/${EMBY_RELEASE}/emby-server-deb_${EMBY_RELEASE}_arm64.deb" && \
   dpkg-deb -xv /tmp/emby.deb /tmp/ && \
   mv -t \
     /app/emby/ \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,43 +1,11 @@
-FROM ghcr.io/linuxserver/baseimage-ubuntu:arm32v7-jammy as buildstage
+# syntax=docker/dockerfile:1
 
-# build args
-ARG EMBY_RELEASE
-ENV DEBIAN_FRONTEND="noninteractive" 
-
-RUN \
-  echo "**** install packages ****" && \
-  apt-get update && \
-  apt-get install -y \
-    cpio \
-    jq \
-    rpm2cpio && \
-  echo "**** install emby ****" && \
-  mkdir -p \
-    /app/emby && \
-  if [ -z ${EMBY_RELEASE+x} ]; then \
-    EMBY_RELEASE=$(curl -s https://api.github.com/repos/MediaBrowser/Emby.Releases/releases/latest \
-    | jq -r '. | .tag_name'); \
-  fi && \
-  curl -o \
-    /tmp/emby.rpm -L \
-    "https://github.com/MediaBrowser/Emby.Releases/releases/download/${EMBY_RELEASE}/emby-server-rpm_${EMBY_RELEASE}_armv7hl.rpm" && \
-  cd /tmp && \
-  rpm2cpio emby.rpm \
-    | cpio -i --make-directories && \
-  mv -t \
-    /app/emby/ \
-    /tmp/opt/emby-server/system/* \
-    /tmp/opt/emby-server/lib/* \
-    /tmp/opt/emby-server/bin/ff* \
-    /tmp/opt/emby-server/etc \
-    /tmp/opt/emby-server/extra/lib/*
-
-# runtime stage
 FROM ghcr.io/linuxserver/baseimage-ubuntu:arm32v7-jammy
 
 # set version label
 ARG BUILD_DATE
 ARG VERSION
+ARG EMBY_RELEASE
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 LABEL maintainer="thelamer"
 
@@ -54,8 +22,25 @@ RUN \
   apt-get install -y --no-install-recommends \
     libomxil-bellagio0 \
     libomxil-bellagio-bin \
-    libraspberrypi0 \
-    netcat && \
+    libraspberrypi0 && \
+  echo "**** install emby ****" && \
+  mkdir -p \
+    /app/emby && \
+  if [ -z ${EMBY_RELEASE+x} ]; then \
+    EMBY_RELEASE=$(curl -s https://api.github.com/repos/MediaBrowser/Emby.Releases/releases/latest \
+    | jq -r '. | .tag_name'); \
+  fi && \
+  curl -o \
+    /tmp/emby.deb -L \
+    "https://github.com/MediaBrowser/Emby.Releases/releases/download/${EMBY_RELEASE}/emby-server-deb_${EMBY_RELEASE}_armhf.deb" && \
+  dpkg-deb -xv /tmp/emby.deb /tmp/ && \
+  mv -t \
+    /app/emby/ \
+    /tmp/opt/emby-server/system/* \
+    /tmp/opt/emby-server/lib/* \
+    /tmp/opt/emby-server/bin/ff* \
+    /tmp/opt/emby-server/etc \
+    /tmp/opt/emby-server/extra/lib/* && \
   echo "**** cleanup ****" && \
   rm -rf \
     /tmp/* \
@@ -63,7 +48,6 @@ RUN \
     /var/tmp/*
 
 # add local files
-COPY --from=buildstage /app/emby /app/emby
 COPY root/ /
 
 # ports and volumes

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -45,7 +45,8 @@ RUN \
   rm -rf \
     /tmp/* \
     /var/lib/apt/lists/* \
-    /var/tmp/*
+    /var/tmp/* && \
+  chmod go+w /tmp
 
 # add local files
 COPY root/ /

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -16,8 +16,8 @@ ENV NVIDIA_DRIVER_CAPABILITIES="compute,video,utility"
 
 RUN \
   echo "**** add emby deps *****" && \
-  curl -s https://keyserver.ubuntu.com/pks/lookup?op=get\&search=0x6587ffd6536b8826e88a62547876ae518cbcf2f2 | apt-key add - && \
-  echo "deb http://ppa.launchpad.net/ubuntu-raspi2/ppa-nightly/ubuntu focal main">> /etc/apt/sources.list.d/raspbins.list && \
+  curl -s https://keyserver.ubuntu.com/pks/lookup?op=get\&search=0x6587ffd6536b8826e88a62547876ae518cbcf2f2 | gpg --dearmor | tee /usr/share/keyrings/raspbins.gpg >/dev/null && \
+  echo "deb [signed-by=/usr/share/keyrings/raspbins.gpg] http://ppa.launchpad.net/ubuntu-raspi2/ppa-nightly/ubuntu focal main">> /etc/apt/sources.list.d/raspbins.list && \
   apt-get update && \
   apt-get install -y --no-install-recommends \
     libomxil-bellagio0 \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -25,7 +25,9 @@ RUN \
     libraspberrypi0 && \
   echo "**** install emby ****" && \
   mkdir -p \
-    /app/emby && \
+    /app/emby \
+    /tmpnetcore && \
+  chmod go+w /tmpnetcore && \
   if [ -z ${EMBY_RELEASE+x} ]; then \
     EMBY_RELEASE=$(curl -s https://api.github.com/repos/MediaBrowser/Emby.Releases/releases/latest \
     | jq -r '. | .tag_name'); \
@@ -45,8 +47,7 @@ RUN \
   rm -rf \
     /tmp/* \
     /var/lib/apt/lists/* \
-    /var/tmp/* && \
-  chmod go+w /tmp
+    /var/tmp/*
 
 # add local files
 COPY root/ /

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -27,7 +27,6 @@ RUN \
   mkdir -p \
     /app/emby \
     /tmpnetcore && \
-  chmod go+w /tmpnetcore && \
   if [ -z ${EMBY_RELEASE+x} ]; then \
     EMBY_RELEASE=$(curl -s https://api.github.com/repos/MediaBrowser/Emby.Releases/releases/latest \
     | jq -r '. | .tag_name'); \

--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **31.05.23:** - Use upstream deb packages instead of rpm.
 * **26.09.22:** - Update chown behavior.
 * **18.09.22:** - Migrate to s6v3, rebase to Ubuntu Jammy.
 * **19.05.21:** - Structural changes upstream.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -90,6 +90,7 @@ app_setup_block: |
 
 # changelog
 changelogs:
+  - { date: "31.05.23:", desc: "Use upstream deb packages instead of rpm." }
   - { date: "26.09.22:", desc: "Update chown behavior." }
   - { date: "18.09.22:", desc: "Migrate to s6v3, rebase to Ubuntu Jammy." }
   - { date: "19.05.21:", desc: "Structural changes upstream." }

--- a/root/etc/s6-overlay/s6-rc.d/init-emby/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-emby/run
@@ -10,7 +10,8 @@ PUID=${PUID:-911}
 if [ -d /config/config ] && [ ! "$(stat -c %u /config/config)" = "$PUID" ]; then
     echo "Change in ownership detected, please be patient while we chown existing files"
     echo "This could take some time"
-    chown abc:abc -R \
+    lsiown abc:abc -R \
         /config
 fi
-lsiown -R abc:abc /tmp/.dotnet
+lsiown abc:abc /tmpnetcore
+chmod 777 /tmp/{.dotnet,.dotnet/shm}

--- a/root/etc/s6-overlay/s6-rc.d/init-emby/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-emby/run
@@ -2,7 +2,8 @@
 
 # Create folders
 mkdir -p \
-    /data
+    /data \
+    /tmp/.dotnet/shm
 
 # check Library permissions
 PUID=${PUID:-911}
@@ -12,3 +13,4 @@ if [ -d /config/config ] && [ ! "$(stat -c %u /config/config)" = "$PUID" ]; then
     chown abc:abc -R \
         /config
 fi
+lsiown -R abc:abc /tmp/.dotnet

--- a/root/etc/s6-overlay/s6-rc.d/svc-emby/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-emby/run
@@ -2,6 +2,7 @@
 
 # env settings
 APP_DIR="/app/emby"
+export TMPDIR="/tmpnetcore"
 export LD_LIBRARY_PATH="${APP_DIR}"
 export FONTCONFIG_PATH="${APP_DIR}"/etc/fonts
 if [ -d "/lib/x86_64-linux-gnu" ]; then

--- a/root/etc/s6-overlay/s6-rc.d/svc-emby/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-emby/run
@@ -10,7 +10,7 @@ fi
 export SSL_CERT_FILE="${APP_DIR}"/etc/ssl/certs/ca-certificates.crt
 
 exec \
-    s6-notifyoncheck -d -n 300 -w 1000 -c "nc -z 127.0.0.1 8096" \
+    s6-notifyoncheck -d -n 300 -w 1000 -c "nc -z localhost 8096" \
         s6-setuidgid abc /app/emby/EmbyServer \
         -programdata /config \
         -ffdetect /app/emby/ffdetect \


### PR DESCRIPTION
No need to use a build stage as the amd64 dockerfile doesn't even install any packages from the apt repo anymore, and nothing is being built.

Rpm packages are among the last to be uploaded to upstream's releases and it's sometimes days before they are uploaded.

Debs seem to be one of the first ones, so they get us quicker builds.

Debs also seem to have the necessary gpu drivers like the rpms did. But this build needs some local tests for transcoding and tone mapping before merge.

UPDATE:
It needed some jumping through hoops because for some reason the binary in the deb packages expected to be able to write all netcore related things to `/tmp` but the abc user does not have write access there. Moving the tmp folder elsewhere fixed most of the issues but we still had to fix perms for `/tmp/.dotnet/shm` because the global mutexes seem to be hardcoded toe xist there (maybe defined build time).

Tested this locally with igpu hw transcode from 4k hevc/hdr to 1080p sdr with tonemapping and everything worked as expected.