### PR TITLE
Fix tonemapping in hw

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,11 +30,7 @@ RUN \
   dpkg-deb -xv /tmp/emby.deb /tmp/emby/ && \
   mv -t \
     /app/emby/ \
-    /tmp/emby/opt/emby-server/system/* \
-    /tmp/emby/opt/emby-server/lib/* \
-    /tmp/emby/opt/emby-server/bin/ff* \
-    /tmp/emby/opt/emby-server/etc \
-    /tmp/emby/opt/emby-server/extra/lib/* && \
+    /tmp/emby/opt/emby-server/* && \
   echo "**** cleanup ****" && \
   rm -rf \
     /tmp/*

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -37,11 +37,7 @@ RUN \
   dpkg-deb -xv /tmp/emby.deb /tmp/emby/ && \
   mv -t \
     /app/emby/ \
-    /tmp/emby/opt/emby-server/system/* \
-    /tmp/emby/opt/emby-server/lib/* \
-    /tmp/emby/opt/emby-server/bin/ff* \
-    /tmp/emby/opt/emby-server/etc \
-    /tmp/emby/opt/emby-server/extra/lib/* && \
+    /tmp/emby/opt/emby-server/* && \
   echo "**** cleanup ****" && \
   rm -rf \
     /tmp/* \

--- a/README.md
+++ b/README.md
@@ -339,6 +339,7 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **19.01.24:** - Fix tonemapping so it's done with hw acceleration.
 * **06.07.23:** - Deprecate armhf. As announced [here](https://www.linuxserver.io/blog/a-farewell-to-arm-hf)
 * **08.06.23:** - Fix package extraction so it doesn't change /tmp perms.
 * **31.05.23:** - Use upstream deb packages instead of rpm.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -83,6 +83,7 @@ app_setup_block: |
   ```
 # changelog
 changelogs:
+  - {date: "19.01.24:", desc: "Fix tonemapping so it's done with hw acceleration."}
   - {date: "06.07.23:", desc: "Deprecate armhf. As announced [here](https://www.linuxserver.io/blog/a-farewell-to-arm-hf)"}
   - {date: "08.06.23:", desc: "Fix package extraction so it doesn't change /tmp perms."}
   - {date: "31.05.23:", desc: "Use upstream deb packages instead of rpm."}

--- a/root/etc/s6-overlay/s6-rc.d/svc-emby/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-emby/run
@@ -2,8 +2,11 @@
 
 # env settings
 APP_DIR="/app/emby"
-export LD_LIBRARY_PATH="${APP_DIR}"/lib
+export LD_LIBRARY_PATH="${APP_DIR}"/lib:"${APP_DIR}"/extra/lib
 export FONTCONFIG_PATH="${APP_DIR}"/etc/fonts
+export OCL_ICD_VENDORS="${APP_DIR}"/extra/etc/OpenCL/vendors
+export AMDGPU_IDS="${APP_DIR}"/extra/share/libdrm/amdgpu.ids
+export PCI_IDS_PATH="${APP_DIR}"/share/hwdata/pci.ids
 if [ -d "/lib/x86_64-linux-gnu" ]; then
     export LIBVA_DRIVERS_PATH=/usr/lib/x86_64-linux-gnu/dri:"${APP_DIR}"/extra/lib/dri
 fi

--- a/root/etc/s6-overlay/s6-rc.d/svc-emby/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-emby/run
@@ -2,18 +2,18 @@
 
 # env settings
 APP_DIR="/app/emby"
-export LD_LIBRARY_PATH="${APP_DIR}"
+export LD_LIBRARY_PATH="${APP_DIR}"/lib
 export FONTCONFIG_PATH="${APP_DIR}"/etc/fonts
 if [ -d "/lib/x86_64-linux-gnu" ]; then
-    export LIBVA_DRIVERS_PATH=/usr/lib/x86_64-linux-gnu/dri:"${APP_DIR}"/dri
+    export LIBVA_DRIVERS_PATH=/usr/lib/x86_64-linux-gnu/dri:"${APP_DIR}"/extra/lib/dri
 fi
 export SSL_CERT_FILE="${APP_DIR}"/etc/ssl/certs/ca-certificates.crt
 
 exec \
     s6-notifyoncheck -d -n 300 -w 1000 -c "nc -z localhost 8096" \
-        s6-setuidgid abc /app/emby/EmbyServer \
+        s6-setuidgid abc /app/emby/bin/EmbyServer \
         -programdata /config \
-        -ffdetect /app/emby/ffdetect \
-        -ffmpeg /app/emby/ffmpeg \
-        -ffprobe /app/emby/ffprobe \
+        -ffdetect /app/emby/bin/ffdetect \
+        -ffmpeg /app/emby/bin/ffmpeg \
+        -ffprobe /app/emby/bin/ffprobe \
         -restartexitcode 3

--- a/root/etc/s6-overlay/s6-rc.d/svc-emby/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-emby/run
@@ -11,7 +11,7 @@ export SSL_CERT_FILE="${APP_DIR}"/etc/ssl/certs/ca-certificates.crt
 
 exec \
     s6-notifyoncheck -d -n 300 -w 1000 -c "nc -z localhost 8096" \
-        s6-setuidgid abc /app/emby/bin/EmbyServer \
+        s6-setuidgid abc /app/emby/system/EmbyServer \
         -programdata /config \
         -ffdetect /app/emby/bin/ffdetect \
         -ffmpeg /app/emby/bin/ffmpeg \


### PR DESCRIPTION
Keep the upstream package files in the same structure, update lib paths

closes #85 