### PR TITLE
Add /app/emby/lib/dri to LIBVA_DRIVERS_PATH for Intel VA-API/QSV

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -114,6 +114,7 @@ init_diagram: |
   "emby:beta" <- Base Images
 # changelog
 changelogs:
+  - {date: "19.06.26:", desc: "Add /app/emby/lib/dri to LIBVA_DRIVERS_PATH so Intel VA-API/QSV hardware transcoding works out of the box."}
   - {date: "12.01.26:", desc: "Set home to /config."}
   - {date: "13.08.24:", desc: "Rebase to Ubuntu Noble."}
   - {date: "12.02.24:", desc: "Use universal hardware acceleration blurb"}

--- a/root/etc/s6-overlay/s6-rc.d/svc-emby/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-emby/run
@@ -8,7 +8,7 @@ export OCL_ICD_VENDORS="${APP_DIR}"/extra/etc/OpenCL/vendors
 export AMDGPU_IDS="${APP_DIR}"/extra/share/libdrm/amdgpu.ids
 export PCI_IDS_PATH="${APP_DIR}"/share/hwdata/pci.ids
 if [[ -d "/lib/x86_64-linux-gnu" ]]; then
-    export LIBVA_DRIVERS_PATH=/usr/lib/x86_64-linux-gnu/dri:"${APP_DIR}"/extra/lib/dri
+    export LIBVA_DRIVERS_PATH=/usr/lib/x86_64-linux-gnu/dri:"${APP_DIR}"/lib/dri:"${APP_DIR}"/extra/lib/dri
 fi
 export SSL_CERT_FILE="${APP_DIR}"/etc/ssl/certs/ca-certificates.crt
 export HOME="/config"


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-emby/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

## Description:
Adds `/app/emby/lib/dri` to `LIBVA_DRIVERS_PATH` in the Emby service run script (`root/etc/s6-overlay/s6-rc.d/svc-emby/run`).

On the beta image, Emby ships its bundled VA-API drivers (iHD, i965, radeonsi, etc.) under `/app/emby/lib/dri`, but the service's `LIBVA_DRIVERS_PATH` only searched `/usr/lib/x86_64-linux-gnu/dri` (empty) and `/app/emby/extra/lib/dri` (not populated on beta). libva therefore couldn't find any driver, and Emby reported:

```
Failed to initialize VA /dev/dri/renderD128. Error -1
```

…for both VAAPI and QuickSync, silently falling back to software (libx264) transcoding on any Intel GPU (Arc dGPU or iGPU). Adding `/app/emby/lib/dri` to the search path lets libva locate the bundled driver. It's appended after the existing entries, so it's harmless on images that ship the driver in `extra/lib/dri` (the path is simply ignored when empty).

A changelog entry has been added to `readme-vars.yml`.

## Benefits of this PR and context:
Restores out-of-the-box Intel hardware transcoding (VAAPI/QSV) on the beta image, which is currently broken for all Intel GPUs. Without this, users get software transcoding with no indication of why hardware acceleration fails. The stable (`latest`) image is unaffected because it ships the driver in `extra/lib/dri`, which is already on the path — but beta moved the driver to `lib/dri`, exposing the gap.

## How Has This Been Tested?
Ran Emby's own detection command (`ffdetect vaencdec`) inside the `lscr.io/linuxserver/emby:beta` container with the service's exact environment, against a real Intel `/dev/dri` device, before and after the change:

- **Before:** `Failed to initialize VA /dev/dri/renderD128. Error -1`, empty Driver, no codecs.
- **After:** `Intel iHD driver for Intel(R) Gen Graphics - 25.3.4`, full decode/encode codec enumeration (H264, HEVC, MPEG2, VC1, etc.).

Test environment: Intel UHD Graphics iGPU, `/dev/dri/renderD128`, image base Ubuntu 24.04 (noble), Emby 4.10.0.x.

## Source / References:
N/A
