### PR TITLE
Fix OCL_ICD_VENDORS path so Intel OpenCL (HDR tonemapping) works

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -114,6 +114,7 @@ init_diagram: |
   "emby:beta" <- Base Images
 # changelog
 changelogs:
+  - {date: "19.06.26:", desc: "Point OCL_ICD_VENDORS at /app/emby/etc/OpenCL/vendors so Intel OpenCL works (fixes HDR tonemapping falling back to software)."}
   - {date: "19.06.26:", desc: "Add /app/emby/lib/dri to LIBVA_DRIVERS_PATH so Intel VA-API/QSV hardware transcoding works out of the box."}
   - {date: "12.01.26:", desc: "Set home to /config."}
   - {date: "13.08.24:", desc: "Rebase to Ubuntu Noble."}

--- a/root/etc/s6-overlay/s6-rc.d/svc-emby/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-emby/run
@@ -4,7 +4,7 @@
 # env settings
 APP_DIR="/app/emby"
 export FONTCONFIG_PATH="${APP_DIR}"/etc/fonts
-export OCL_ICD_VENDORS="${APP_DIR}"/extra/etc/OpenCL/vendors
+export OCL_ICD_VENDORS="${APP_DIR}"/etc/OpenCL/vendors
 export AMDGPU_IDS="${APP_DIR}"/extra/share/libdrm/amdgpu.ids
 export PCI_IDS_PATH="${APP_DIR}"/share/hwdata/pci.ids
 if [[ -d "/lib/x86_64-linux-gnu" ]]; then


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-emby/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

## Description:
Points `OCL_ICD_VENDORS` at `/app/emby/etc/OpenCL/vendors` in the Emby service run script (`root/etc/s6-overlay/s6-rc.d/svc-emby/run`).

The service exported `OCL_ICD_VENDORS=/app/emby/extra/etc/OpenCL/vendors`, which does not exist in the image. The OpenCL ICD loader therefore found no platforms and ffmpeg failed to create an OpenCL device:

```
[AVHWDeviceContext] Failed to get number of OpenCL platforms: -1001.
Device creation failed: -19.
```

(`-1001` = `CL_PLATFORM_NOT_FOUND_KHR`.) As a result, Intel HDR→SDR tonemapping (the `vpp_qsv → hwmap(opencl) → tonemap_opencl → hwmap(qsv)` filter chain) failed with `Error reinitializing filters`, and Emby fell back to slow software (libx264) transcoding.

The actual ICD vendor files ship at `/app/emby/etc/OpenCL/vendors` (`intel.icd` / `intel_legacy1.icd`), which reference `libigdrcl.so` — already resolvable via the service's `LD_LIBRARY_PATH` (`/app/emby/lib`). Pointing `OCL_ICD_VENDORS` at the real directory restores the full hardware tonemapping pipeline.

A changelog entry has been added to `readme-vars.yml`.

## Benefits of this PR and context:
Restores hardware HDR tonemapping on Intel GPUs (QuickSync + OpenCL). Without this, any HDR→SDR transcode silently drops to software encoding, which is dramatically slower (observed ~3–4x vs ~12x on the same Arc A380). The official `emby/embyserver` image sets this env correctly, so this brings the LSIO image in line.

## How Has This Been Tested?
On a real Intel iGPU, ran ffmpeg's OpenCL device init inside the `lscr.io/linuxserver/emby:beta` container with the service's exact env, before and after the change:

- **Before** (`OCL_ICD_VENDORS=/app/emby/extra/etc/OpenCL/vendors`): `Failed to get number of OpenCL platforms: -1001`, exit 1.
- **After** (`OCL_ICD_VENDORS=/app/emby/etc/OpenCL/vendors`): OpenCL device created, exit 0.

This matches real-world transcode logs where the LSIO image fell back to software while the official image completed the QSV+OpenCL tonemap pipeline.

## Source / References:
N/A
