### PR TITLE
Fix AMDGPU_IDS_PATH so libdrm can find amdgpu.ids

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -91,6 +91,7 @@ init_diagram: |
   "emby:beta" <- Base Images
 # changelog
 changelogs:
+  - {date: "29.07.26:", desc: "Fix AMDGPU_IDS_PATH so libdrm can find amdgpu.ids (the previous AMDGPU_IDS pointed at a non-existent path and was unread)."}
   - {date: "14.07.26:", desc: "Rebase to Ubuntu Resolute."}
   - {date: "19.06.26:", desc: "Point OCL_ICD_VENDORS at /app/emby/etc/OpenCL/vendors so Intel OpenCL works (fixes HDR tonemapping falling back to software)."}
   - {date: "19.06.26:", desc: "Add /app/emby/lib/dri to LIBVA_DRIVERS_PATH so Intel VA-API/QSV hardware transcoding works out of the box."}

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -91,7 +91,7 @@ init_diagram: |
   "emby:beta" <- Base Images
 # changelog
 changelogs:
-  - {date: "29.07.26:", desc: "Fix AMDGPU_IDS_PATH so libdrm can find amdgpu.ids (the previous AMDGPU_IDS pointed at a non-existent path and was unread)."}
+  - {date: "11.09.26:", desc: "Fix AMDGPU_IDS_PATH so libdrm can find amdgpu.ids (the previous AMDGPU_IDS pointed at a non-existent path and was unread)."}
   - {date: "14.07.26:", desc: "Rebase to Ubuntu Resolute."}
   - {date: "19.06.26:", desc: "Point OCL_ICD_VENDORS at /app/emby/etc/OpenCL/vendors so Intel OpenCL works (fixes HDR tonemapping falling back to software)."}
   - {date: "19.06.26:", desc: "Add /app/emby/lib/dri to LIBVA_DRIVERS_PATH so Intel VA-API/QSV hardware transcoding works out of the box."}

--- a/root/etc/s6-overlay/s6-rc.d/svc-emby/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-emby/run
@@ -5,7 +5,7 @@
 APP_DIR="/app/emby"
 export FONTCONFIG_PATH="${APP_DIR}"/etc/fonts
 export OCL_ICD_VENDORS="${APP_DIR}"/etc/OpenCL/vendors
-export AMDGPU_IDS="${APP_DIR}"/extra/share/libdrm/amdgpu.ids
+export AMDGPU_IDS_PATH="${APP_DIR}"/share/libdrm/amdgpu.ids
 export PCI_IDS_PATH="${APP_DIR}"/share/hwdata/pci.ids
 if [[ -d "/lib/x86_64-linux-gnu" ]]; then
     export LIBVA_DRIVERS_PATH=/usr/lib/x86_64-linux-gnu/dri:"${APP_DIR}"/lib/dri:"${APP_DIR}"/extra/lib/dri


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-emby/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

## Description:
Heads up: I only have **Intel** hardware, so I could **not** test this on an AMD GPU. I'm raising it because the env line looks dead/misnamed and there's a probable fix — but it needs confirmation from an AMD GPU owner before being relied upon.

In `root/etc/s6-overlay/s6-rc.d/svc-emby/run`, the service exports:

```sh
export AMDGPU_IDS="${APP_DIR}"/extra/share/libdrm/amdgpu.ids
```

**What I can verify (Intel host, `emby:beta`, 4.10.0.15):**
- That path does not exist — the whole `/app/emby/extra` tree is absent from the image.
- `grep -rI AMDGPU_IDS /app/emby` finds **no consumer** of the variable name `AMDGPU_IDS`, so that line appears to be a no-op.
- The real table ships at `/app/emby/share/libdrm/amdgpu.ids`.
- Emby's own bundled wrapper scripts (`/app/emby/bin/emby-ffmpeg`, `emby-server`, etc.) instead export `AMDGPU_IDS_PATH=$APP_DIR/share/libdrm/amdgpu.ids` (note: different variable name). The service runs the raw `/app/emby/bin/ffmpeg`, not those wrappers, so it doesn't inherit that value.

This PR aligns the service env with Emby's own wrappers:

```diff
-export AMDGPU_IDS="${APP_DIR}"/extra/share/libdrm/amdgpu.ids
+export AMDGPU_IDS_PATH="${APP_DIR}"/share/libdrm/amdgpu.ids
```

**What I could NOT verify (please confirm):**
- Whether anything actually reads `AMDGPU_IDS_PATH` at runtime — I found no matching string in `libdrm_amdgpu.so`, and libdrm may fall back to a working default.
- Whether AMD users see any real impact. `amdgpu.ids` is a PCI-ID→name lookup table, so worst case is likely a cosmetic blank/generic adapter name rather than broken transcoding.

## Benefits of this PR and context:
Aligns the service's hardware-accel env with the values Emby's own `emby-*` wrapper scripts use, and removes a dead/misnamed env line. If `AMDGPU_IDS_PATH` is consumed on AMD, this lets libdrm resolve `amdgpu.ids` correctly.

## How Has This Been Tested?
Not tested on AMD hardware (I don't have an AMD GPU). On an Intel host I verified the filesystem facts above (missing `extra/` path, real file location, no consumer of the `AMDGPU_IDS` name, and the wrapper scripts' use of `AMDGPU_IDS_PATH`). Could an AMD GPU owner confirm whether this changes hardware detection / VAAPI behaviour on AMD?

## Source / References:
Emby's bundled wrapper scripts in the image (`/app/emby/bin/emby-ffmpeg` etc.) export `AMDGPU_IDS_PATH=$APP_DIR/share/libdrm/amdgpu.ids`.
